### PR TITLE
Update paranoia, Mac OS Tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -32,4 +32,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,5 +40,6 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: ${{ matrix.os == 'ubuntu-22.04' && 'bottles' || 'bottles-macos' }}
+          name: bottles
+          # name: ${{ matrix.os == 'ubuntu-22.04' && 'bottles' || 'bottles-macos' }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-15, macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: bottles
-          # name: ${{ matrix.os == 'ubuntu-22.04' && 'bottles' || 'bottles-macos' }}
+          name: ${{ matrix.os == 'ubuntu-22.04' && 'bottles' || 'bottles-macos' }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-15]
-        bottles: [bottles, macos-bottles]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -41,5 +40,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: ${{ matrix.bottles }}
+          name: ${{ matrix.os == 'ubuntu-22.04' && 'bottles' || 'bottles-macos' }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-15]
+        bottles: [bottles, macos-bottles]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -40,5 +41,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: bottles
+          name: ${{ matrix.bottles }}
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15, macos-14, macos-13]
+        os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Formula/jsctl.rb
+++ b/Formula/jsctl.rb
@@ -36,6 +36,6 @@ class Jsctl < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("jsctl version")
+    assert_match version.to_s, shell_output(bin/"jsctl version")
   end
 end

--- a/Formula/jsctl.rb
+++ b/Formula/jsctl.rb
@@ -36,6 +36,6 @@ class Jsctl < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output(bin/"jsctl version")
+    assert_match version.to_s, shell_output("bin/jsctl version")
   end
 end

--- a/Formula/jsctl.rb
+++ b/Formula/jsctl.rb
@@ -32,10 +32,10 @@ class Jsctl < Formula
     # The tar we downloaded has the binary already in it just called jsctl
     bin.install "jsctl"
     # Use the binary to generate shell completions
-    generate_completions_from_executable(bin/"jsctl", "completion")
+    generate_completions_from_executable("#{bin}/jsctl", "completion")
   end
 
   test do
-    assert_match version.to_s, shell_output("bin/jsctl version")
+    assert_match version.to_s, shell_output("#{bin}/jsctl version")
   end
 end

--- a/Formula/paranoia.rb
+++ b/Formula/paranoia.rb
@@ -27,6 +27,6 @@ class Paranoia < Formula
     # This string is the SHA256 of the "ISRG X1 Root" certificate. This test verifies that
     # paranoia can find that certificate in a known image (cert-manager v1.9.1).
     assert_match "96bcec06264976f37460779acf28c5a7cfe8a3c0aae11a8ffcee05c0bddf08c6",
-      shell_output("bin/paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
+      shell_output(bin/"paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
   end
 end

--- a/Formula/paranoia.rb
+++ b/Formula/paranoia.rb
@@ -2,7 +2,7 @@ class Paranoia < Formula
   desc "Inspect certificate authorites in contianer images"
   homepage "https://github.com/jetstack/paranoia"
   url "https://github.com/jetstack/paranoia/archive/refs/tags/v0.3.0.tar.gz"
-  sha256 "19783029ddccfa5666e202156a7f2aa5014c952e42ecf5707838919fbbdb1c82"
+  sha256 "2dbfd2e91b750897a96389db30f7e19e5474edf2d540b6d2655f90c3d65cf826"
   license "Apache-2.0"
   head "https://github.com/jetstack/paranoia.git", branch: "main"
 

--- a/Formula/paranoia.rb
+++ b/Formula/paranoia.rb
@@ -27,6 +27,6 @@ class Paranoia < Formula
     # This string is the SHA256 of the "ISRG X1 Root" certificate. This test verifies that
     # paranoia can find that certificate in a known image (cert-manager v1.9.1).
     assert_match "96bcec06264976f37460779acf28c5a7cfe8a3c0aae11a8ffcee05c0bddf08c6",
-      shell_output(bin/"paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
+      shell_output("bin/paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
   end
 end

--- a/Formula/paranoia.rb
+++ b/Formula/paranoia.rb
@@ -1,13 +1,13 @@
 class Paranoia < Formula
   desc "Inspect certificate authorites in contianer images"
   homepage "https://github.com/jetstack/paranoia"
-  url "https://github.com/jetstack/paranoia/archive/refs/tags/v0.2.1.tar.gz"
+  url "https://github.com/jetstack/paranoia/archive/refs/tags/v0.3.0.tar.gz"
   sha256 "19783029ddccfa5666e202156a7f2aa5014c952e42ecf5707838919fbbdb1c82"
   license "Apache-2.0"
   head "https://github.com/jetstack/paranoia.git", branch: "main"
 
   bottle do
-    root_url "https://github.com/jetstack/homebrew-jetstack/releases/download/paranoia-0.2.1"
+    root_url "https://github.com/jetstack/homebrew-jetstack/releases/download/paranoia-0.3.0"
     sha256 cellar: :any_skip_relocation, monterey:     "72247ad301045a7ae873c9ac1b06e967ae9ef7bae03d52345997ca228821ad7c"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "eae0d69009f562a3f42ed2b777442df34a1de642f21325514114a173e678d6ee"
   end

--- a/Formula/paranoia.rb
+++ b/Formula/paranoia.rb
@@ -27,6 +27,6 @@ class Paranoia < Formula
     # This string is the SHA256 of the "ISRG X1 Root" certificate. This test verifies that
     # paranoia can find that certificate in a known image (cert-manager v1.9.1).
     assert_match "96bcec06264976f37460779acf28c5a7cfe8a3c0aae11a8ffcee05c0bddf08c6",
-      shell_output("paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
+      shell_output("bin/paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
   end
 end

--- a/Formula/paranoia.rb
+++ b/Formula/paranoia.rb
@@ -20,13 +20,13 @@ class Paranoia < Formula
     system "go", "run", "./hack/generate-manual"
     man1.install Pathname.glob("man/*.1")
     # Use the binary to generate shell completions
-    generate_completions_from_executable(bin/"paranoia", "completion")
+    generate_completions_from_executable("#{bin}/paranoia", "completion")
   end
 
   test do
     # This string is the SHA256 of the "ISRG X1 Root" certificate. This test verifies that
     # paranoia can find that certificate in a known image (cert-manager v1.9.1).
     assert_match "96bcec06264976f37460779acf28c5a7cfe8a3c0aae11a8ffcee05c0bddf08c6",
-      shell_output("bin/paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
+      shell_output("#{bin}/paranoia export --output wide quay.io/jetstack/cert-manager-controller:v1.9.1")
   end
 end


### PR DESCRIPTION
macos-12 is now deprecated, I have added all available versions of macos to ensure we get full coverage, Also increasing the version of Paranoia to latest.  